### PR TITLE
Publish all MAS data to GBIF

### DIFF
--- a/source/markdown/data_controle_2024.Rmd
+++ b/source/markdown/data_controle_2024.Rmd
@@ -1425,7 +1425,7 @@ Het gaat om de volgende stappen (zie ook `dwc_mapping_mas.Rmd` voor een uitgebre
 - Dataset preparatie
   - We verwijderen kolommen gerelateerd aan steekproef
   - We voegen de finale data samen met MAS data die buiten MBAG valt
-    - De kolom `mas_sample` duidt aan of ze bij MBAG - MAS horen of niet
+    - De kolom `is_mas_sample` duidt aan of ze bij MBAG - MAS horen of niet
   - We passen kolomnamen aan
 - Ruimtelijke verwerking
   - We verwijderen de Amersfoord coördinaten
@@ -1589,6 +1589,6 @@ Overige opmerkingen en vragen:
   - We kijken over de hele dataset naar de lijst van soorten en voegen zo afwezigheden per telpunt toe op basis van deze lijst van soorten. *Voordeel:* steeds meer volledige lijst van soorten. *Nadeel:* dataset zal elk jaar veranderen.
   - Afwezigheden toevoegen o.b.v. externe lijst?
   - ...
-- Buiten MBAG - MAS, publiceren we ook de overige MAS data van de Sovon export. Is de kolomnaam `sample_mas` ok?
+- Buiten MBAG - MAS, publiceren we ook de overige MAS data van de Sovon export. Is de kolomnaam `is_mas_sample` ok?
 
 > Zouden afwezigheden correct zijn? Er is geen streeplijst gebruikt, dus eerder niet.

--- a/source/markdown/data_controle_2024.Rmd
+++ b/source/markdown/data_controle_2024.Rmd
@@ -1424,6 +1424,8 @@ Het gaat om de volgende stappen (zie ook `dwc_mapping_mas.Rmd` voor een uitgebre
 
 - Dataset preparatie
   - We verwijderen kolommen gerelateerd aan steekproef
+  - We voegen de finale data samen met MAS data die buiten MBAG valt
+    - De kolom `mas_sample` duidt aan of ze bij MBAG - MAS horen of niet
   - We passen kolomnamen aan
 - Ruimtelijke verwerking
   - We verwijderen de Amersfoord coördinaten
@@ -1582,11 +1584,11 @@ glimpse(dwc_mapping_final)
 Overige opmerkingen en vragen:
 
 - Ok dat `varbatimBehavior` de Nederlandstalige beschrijving is? De Engelstalige beschrijving staat onder `behavior`. Of mag de Nederlandse beschrijving weg?
--  Wat is het verschil tussen `dwc_individualCount` en `dwc_organismQuantity`? Voorlopig gebruiken we `organismQuantity` voor aantallen en `organismQuantityType = individuals` wanneer broedcode gelijk aan 0 en `organismQuantityType = breeding pairs` wanneer broedcode > 0. In geval van broedcode > 0 moet `organismQuantity` eigenlijk gelijk zijn aan 1.
 - We kunnen ook afwezigheden toevoegen (`occurrenceStatus = "absent"` en `organismQuantity = 0`) aangezien alle vogels worden genoteerd op het moment van tellen vanaf dat telpunt. Hoe doen we dit?
   - We kijken per jaar naar de lijst van soorten en voegen zo afwezigheden per telpunt toe op basis van deze lijst van soorten per jaar. *Voordeel:* geen verandering als er data van een nieuw jaar bijkomt. *Nadeel:* niet volledig aangezien deze lijst niet volledig is.
   - We kijken over de hele dataset naar de lijst van soorten en voegen zo afwezigheden per telpunt toe op basis van deze lijst van soorten. *Voordeel:* steeds meer volledige lijst van soorten. *Nadeel:* dataset zal elk jaar veranderen.
   - Afwezigheden toevoegen o.b.v. externe lijst?
   - ...
+- Buiten MBAG - MAS, publiceren we ook de overige MAS data van de Sovon export. Is de kolomnaam `sample_mas` ok?
 
 > Zouden afwezigheden correct zijn? Er is geen streeplijst gebruikt, dus eerder niet.

--- a/source/targets/data_preparation/R/data_preparation.R
+++ b/source/targets/data_preparation/R/data_preparation.R
@@ -225,7 +225,7 @@ rbind_all_mas_data <- function(sample_data, extra_data) {
     bind_rows(sample_data) %>%
     select(all_of(names(sample_data))) %>%
 
-    # Add column to distinguish sampleand non-sample data
+    # Add column to distinguish sample and non-sample data
     mutate(mas_sample = oid %in% sample_oids)
 
 

--- a/source/targets/data_preparation/R/data_preparation.R
+++ b/source/targets/data_preparation/R/data_preparation.R
@@ -226,7 +226,7 @@ rbind_all_mas_data <- function(sample_data, extra_data) {
     select(all_of(names(sample_data))) %>%
 
     # Add column to distinguish sample and non-sample data
-    mutate(mas_sample = oid %in% sample_oids)
+    mutate(mas_sample = .data$oid %in% sample_oids)
 
 
   return(complete_df)

--- a/source/targets/data_preparation/R/data_preparation.R
+++ b/source/targets/data_preparation/R/data_preparation.R
@@ -226,7 +226,7 @@ rbind_all_mas_data <- function(sample_data, extra_data) {
     select(all_of(names(sample_data))) %>%
 
     # Add column to distinguish sample and non-sample data
-    mutate(mas_sample = .data$oid %in% sample_oids)
+    mutate(is_mas_sample = .data$oid %in% sample_oids)
 
 
   return(complete_df)

--- a/source/targets/data_preparation/R/data_preparation.R
+++ b/source/targets/data_preparation/R/data_preparation.R
@@ -197,3 +197,37 @@ remove_columns <- function(data_sf) {
 
   return(out_sf)
 }
+
+# Add non-MAS data to MAS data for GBIF publication
+rbind_all_mas_data <- function(sample_data, extra_data) {
+  require("dplyr")
+  require("rlang")
+  require("lubridate")
+
+  # Identify IDs from final MBAG - MAS data
+  sample_oids <- sample_data$oid
+
+  # Add extra data to sample data
+  complete_df <- extra_data %>%
+    # Recalculate and columns to comply with protocol data
+    mutate(distance2plot = NA,
+           datum = ymd(paste(.data$jaar, .data$maand, .data$dag, sep = "-"))
+    ) %>%
+    rename(waarnemer = "waarneme") %>%
+
+    # Only keep data not already in MAS sample
+    dplyr::filter(!.data$oid %in% sample_oids) %>%
+
+    # Adjust subspecies names
+    adjust_subspecies_names_nl() %>%
+
+    # Add final MAS sample data and keep final columns
+    bind_rows(sample_data) %>%
+    select(all_of(names(sample_data))) %>%
+
+    # Add column to distinguish sampleand non-sample data
+    mutate(mas_sample = oid %in% sample_oids)
+
+
+  return(complete_df)
+}

--- a/source/targets/data_preparation/R/dwc_mapping.R
+++ b/source/targets/data_preparation/R/dwc_mapping.R
@@ -86,7 +86,8 @@ unchanged_mapping <- function(data_df) {
       "dwc_locationID"         = "raw_plotnaam",
       "dwc_varbatimBehavior"   = "raw_wrntype_omschrijving",
       "dwc_occurrenceRemarks"  = "raw_opmerk",
-      "dwc_taxonID"            = "raw_soortnr"
+      "dwc_taxonID"            = "raw_soortnr",
+      "dwc_mas_sample"         = "raw_mas_sample"
     ) %>%
     mutate(
       dwc_identifiedBy = .data$dwc_recordedBy
@@ -125,8 +126,13 @@ modified_mapping <- function(data_df) {
         .data$dwc_varbatimBehavior == "Paar in broedbiotoop" ~
           "Pair in breeding habitat"
         ),
-      dwc_coordinateUncertaintyInMeters = ifelse(
-        .data$raw_distance2plot < 100, 10, 0.1 * .data$raw_distance2plot),
+      # If the distance is < 100 m --> 10 m
+      # If the distance is >= 100 m --> 0.1 * distance
+      # If the distance is unknown --> 30 m (0.1 * 300 m)
+      dwc_coordinateUncertaintyInMeters =
+        ifelse(is.na(.data$raw_distance2plot), 30,
+          ifelse(.data$raw_distance2plot < 100,
+                 10, 0.1 * .data$raw_distance2plot)),
       dwc_organismQuantityType = ifelse(.data$raw_wrntype == "0",
                                         "individuals", "breeding pairs")
     ) %>%
@@ -238,7 +244,7 @@ finalise_dwc_df <- function(data_df, taxonomy_df) {
   col_order <- c(
     "type", "language", "license", "publisher", "rightsHolder", "accessRights",
     "datasetID", "collectionCode", "institutionCode", "datasetName",
-    "basisOfRecord", "eventType", "eventID",
+    "basisOfRecord", "eventType", "eventID", "mas_sample",
     "occurrenceID", "recordedBy", "organismQuantity",
     "organismQuantityType", "occurrenceStatus", "behavior", "varbatimBehavior",
     "occurrenceRemarks", "samplingProtocol", "samplingEffort", "eventDate",

--- a/source/targets/data_preparation/R/dwc_mapping.R
+++ b/source/targets/data_preparation/R/dwc_mapping.R
@@ -87,7 +87,7 @@ unchanged_mapping <- function(data_df) {
       "dwc_varbatimBehavior"   = "raw_wrntype_omschrijving",
       "dwc_occurrenceRemarks"  = "raw_opmerk",
       "dwc_taxonID"            = "raw_soortnr",
-      "dwc_mas_sample"         = "raw_mas_sample"
+      "dwc_is_mas_sample"         = "raw_is_mas_sample"
     ) %>%
     mutate(
       dwc_identifiedBy = .data$dwc_recordedBy
@@ -244,7 +244,7 @@ finalise_dwc_df <- function(data_df, taxonomy_df) {
   col_order <- c(
     "type", "language", "license", "publisher", "rightsHolder", "accessRights",
     "datasetID", "collectionCode", "institutionCode", "datasetName",
-    "basisOfRecord", "eventType", "eventID", "mas_sample",
+    "basisOfRecord", "eventType", "eventID", "is_mas_sample",
     "occurrenceID", "recordedBy", "organismQuantity",
     "organismQuantityType", "occurrenceStatus", "behavior", "varbatimBehavior",
     "occurrenceRemarks", "samplingProtocol", "samplingEffort", "eventDate",

--- a/source/targets/data_preparation/_targets.R
+++ b/source/targets/data_preparation/_targets.R
@@ -239,9 +239,13 @@ list(
     command = map_taxa_manual(
       taxonomy_df = taxon_mapping,
       manual_taxon_list = list(
-        "Veldmuis/Aardmuis" = 2438591, # genus
-        "rat spec." = 2439223,         # genus
-        "spitsmuis spec." = 5534       # family
+        "Huismuis (zoogdier)" = 7429082,        # species
+        "Barmsijs (Grote of Kleine)" = 6782561, # genus
+        "Veldmuis/Aardmuis" = 2438591,          # genus
+        "Wezel/Hermelijn" = 2433922,            # genus
+        "groene kikker-complex" = 2426629,      # genus
+        "rat spec." = 2439223,                  # genus
+        "spitsmuis spec." = 5534                # family
       ),
       vernacular_name_col = "dwc_vernacularName",
       out_cols = c("scientificName", "phylum", "order", "family", "genus",

--- a/source/targets/data_preparation/_targets.R
+++ b/source/targets/data_preparation/_targets.R
@@ -191,7 +191,7 @@ list(
     )
   ),
   # Add non-MAS data to MAS data for GBIF publication
-  # Column mas_sample indicates whether the observation is part of the
+  # Column is_mas_sample indicates whether the observation is part of the
   # MBAG - MAS data or not
   tar_target(
     name = complete_data_gbif_raw,

--- a/source/targets/data_preparation/_targets.R
+++ b/source/targets/data_preparation/_targets.R
@@ -181,12 +181,30 @@ list(
 
   # 4. Prepare data for publication on GBIF
 
+  # Stop branching over years, bind all data together
+  # Complete dataset from beginning pipeline
+  tar_target(
+    name = complete_data_crs,
+    command = do.call(
+      what = rbind.data.frame,
+      args = c(crs_pipeline, make.row.names = FALSE)
+    )
+  ),
+  # Add non-MAS data to MAS data for GBIF publication
+  # Column mas_sample indicates whether the observation is part of the
+  # MBAG - MAS data or not
+  tar_target(
+    name = complete_data_gbif_raw,
+    command = rbind_all_mas_data(
+      sample_data = mas_data_clean,
+      extra_data = complete_data_crs
+    )
+  ),
   # Perform mapping of Darwin Core column names
   tar_target(
     name = darwincore_mapping,
-    command = dwc_mapping(mas_data_clean)
+    command = dwc_mapping(complete_data_gbif_raw)
   ),
-
   # Get taxon names and split dataframe in groups of `size`
   tarchetypes::tar_group_size(
     name = prepare_taxon_mapping,


### PR DESCRIPTION
We do not only want to publisch the MBAG - MAS data to GBIF, but all MAS data from sovon. This former data is collected

- at certain sampling units part of the MBAG - MAS sampling frame
- starting from 2022
- within specific counting periods during the year
- within a specific radius (300 m)

Counts using the MAS protocol have been happening since 2018 and sometimes fall outside the above time periods, radius ...
With this PR, we also add the latter data to the GBIF publication. Here are the most important changes:

- column `sample_mas`
  - indicates whether the observations is part of the  MBAG - MAS data (`TRUE`) or not (`FALSE`)
  - is this a good column name? ask data publishing colleagues for DarwinCore?
- `coordinateUncertaintyInMeters`
  - `sample_mas` TRUE: 10 m if distance to observer is < 100 m and 0.1*distance if distance to observer is > 100 m
  - `sample_mas` FALSE: 30 m