### PR TITLE
Security: GitHub Actions pinnen op volledige commit-SHA

### DIFF
--- a/.github/workflows/check_project.yml
+++ b/.github/workflows/check_project.yml
@@ -14,4 +14,4 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: inbo/actions/check_project@main
+      - uses: inbo/actions/check_project@5ad8ad6a75c216b77713aa14ebaef30d76ee1463 # main


### PR DESCRIPTION
_Onderdeel van een INBO-brede security-hardening: SHA-pinning van GitHub Actions. Aanbevolen door o.a. [GitHub Security Hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)._